### PR TITLE
Fix the case where we have both an XmlRootAttribute and an anonymous XmlTypeAttribute

### DIFF
--- a/Xsd2.Tests/Schemas/Issue12.cs
+++ b/Xsd2.Tests/Schemas/Issue12.cs
@@ -8,7 +8,6 @@ namespace Xsd2 {
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://codaxy.com/xsd2/Test.xsd")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://codaxy.com/xsd2/Test.xsd", IsNullable=true)]
     public partial class UpperCaseType {
         
         private int valueField;
@@ -64,7 +63,6 @@ namespace Xsd2 {
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://codaxy.com/xsd2/Test.xsd")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://codaxy.com/xsd2/Test.xsd", IsNullable=true)]
     public partial class LowerCaseType {
         
         private int valueField;

--- a/Xsd2.Tests/Schemas/form.cs
+++ b/Xsd2.Tests/Schemas/form.cs
@@ -178,7 +178,6 @@ namespace Xsd2 {
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://example.org/Form.xsd")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://example.org/Form.xsd", IsNullable=true)]
     public partial class Element {
     }
     
@@ -235,14 +234,13 @@ namespace Xsd2 {
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://example.org/Form.xsd")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://example.org/Form.xsd", IsNullable=true)]
     public partial class Container : Element {
         
-        private List<Field> itemsField;
+        private System.Collections.Generic.List<Field> itemsField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute("field")]
-        public List<Field> Items {
+        public System.Collections.Generic.List<Field> Items {
             get {
                 return this.itemsField;
             }
@@ -257,15 +255,14 @@ namespace Xsd2 {
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="http://example.org/Form.xsd")]
-    [System.Xml.Serialization.XmlRootAttribute(Namespace="http://example.org/Form.xsd", IsNullable=true)]
     public partial class MixedContainer : Element {
         
-        private List<System.Object> itemsField;
+        private System.Collections.Generic.List<object> itemsField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute("field")]
         [System.Xml.Serialization.XmlTextAttribute(typeof(string))]
-        public List<System.Object> Items {
+        public System.Collections.Generic.List<object> Items {
             get {
                 return this.itemsField;
             }

--- a/Xsd2/XsdCodeGenerator.cs
+++ b/Xsd2/XsdCodeGenerator.cs
@@ -650,7 +650,6 @@ namespace Xsd2
         private static void SetAttributeOriginalName(CodeTypeMember member, string originalName, string newAttributeType)
         {
             var elementIgnored = false;
-            var isAnonymous = false;
             var attributesThatNeedName = new List<CodeAttributeDeclaration>();
             foreach (CodeAttributeDeclaration attribute in member.CustomAttributes)
             {
@@ -663,23 +662,14 @@ namespace Xsd2
                     case "System.Xml.Serialization.XmlElementAttribute":
                     case "System.Xml.Serialization.XmlArrayItemAttribute":
                     case "System.Xml.Serialization.XmlEnumAttribute":
+                    case "System.Xml.Serialization.XmlTypeAttribute":
                     case "System.Xml.Serialization.XmlRootAttribute":
                         attributesThatNeedName.Add(attribute);
-                        break;
-                    case "System.Xml.Serialization.XmlTypeAttribute":
-                        if (!attribute.IsAnonymousTypeArgument())
-                        {
-                            attributesThatNeedName.Add(attribute);
-                        }
-                        else
-                        {
-                            isAnonymous = true;
-                        }
                         break;
                 }
             }
 
-            if (elementIgnored || isAnonymous)
+            if (elementIgnored)
                 return;
 
             if (attributesThatNeedName.Count == 0)
@@ -693,6 +683,14 @@ namespace Xsd2
 
             foreach (var attribute in attributesThatNeedName)
             {
+                switch (attribute.Name)
+                {
+                    case "System.Xml.Serialization.XmlTypeAttribute":
+                        if (attribute.IsAnonymousTypeArgument())
+                            continue;
+                        break;
+                }
+
                 var hasNameAttribute = attribute.Arguments.Cast<CodeAttributeArgument>().Any(x => x.IsNameArgument());
                 if (!hasNameAttribute)
                     attribute.Arguments.Insert(0, nameArgument);

--- a/Xsd2/XsdCodeGenerator.cs
+++ b/Xsd2/XsdCodeGenerator.cs
@@ -405,7 +405,7 @@ namespace Xsd2
                             {
                                 TypeArguments =
                                 {
-                                    field.Type
+                                    field.Type.ArrayElementType
                                 }
                             };
 
@@ -450,7 +450,7 @@ namespace Xsd2
                             {
                                 TypeArguments =
                                 {
-                                    property.Type
+                                    property.Type.ArrayElementType
                                 }
                             };
 


### PR DESCRIPTION
In this case, the name of the XmlRootAttribute must be set when we renamed the type.