### PR TITLE
Fix email typo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2018 Codaxy d.o.o. (license@codaxy,com)
+Copyright 2018 Codaxy d.o.o. (license@codaxy.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Not sure why the last paragraph is shown as edited, probably because of different formatting (I used github's web interface to make the change).
So just to confirm, no real changes were made except for the email typo. 